### PR TITLE
Perbaikan untuk GetPlayerForwardVector

### DIFF
--- a/left4bots_afterload.nut
+++ b/left4bots_afterload.nut
@@ -481,7 +481,8 @@ printl("enforce shotgun or sniper rifle");
 ::DetectDynamicObstacles <- function(bot)
 {
 	local botOrigin = bot.GetOrigin();
-	local forward = bot.GetPlayerForwardVector();
+	local angles = bot.GetAbsAngles();
+	local forward = AngleVectors(angles);
 	local checkPos = botOrigin + (forward * 100); // Periksa 100 unit di depan bot
 
 	// Periksa pintu


### PR DESCRIPTION
Perubahan ini menggantikan panggilan ke `GetPlayerForwardVector()` yang tidak ada dengan `AngleVectors(bot.GetAbsAngles())` untuk mendapatkan vektor maju bot. Ini memperbaiki kesalahan yang mencegah deteksi rintangan dinamis berfungsi.