### PR TITLE
Perbaikan untuk GetAimVector

### DIFF
--- a/left4bots_afterload.nut
+++ b/left4bots_afterload.nut
@@ -481,8 +481,7 @@ printl("enforce shotgun or sniper rifle");
 ::DetectDynamicObstacles <- function(bot)
 {
 	local botOrigin = bot.GetOrigin();
-	local angles = bot.GetAbsAngles();
-	local forward = AngleVectors(angles);
+	local forward = bot.GetAimVector();
 	local checkPos = botOrigin + (forward * 100); // Periksa 100 unit di depan bot
 
 	// Periksa pintu


### PR DESCRIPTION
Perubahan ini menggantikan panggilan ke `GetAbsAngles()` yang tidak ada dengan `GetAimVector()` untuk mendapatkan vektor maju bot. Ini memperbaiki kesalahan yang mencegah deteksi rintangan dinamis berfungsi.