### PR TITLE
Fix for 'null vector' Error

### DIFF
--- a/left4bots_afterload.nut
+++ b/left4bots_afterload.nut
@@ -485,7 +485,8 @@ printl("enforce shotgun or sniper rifle");
 	local forward;
 	if (velocity.LengthSqr() > 0)
 	{
-		forward = velocity.Norm();
+		forward = Vector(velocity.x, velocity.y, velocity.z);
+		forward.Norm();
 	}
 	else
 	{


### PR DESCRIPTION
This change fixes a `null vector` error that occurred when normalizing the velocity vector. Now, a copy of the vector is made before normalization to ensure that the correct values are returned.