### PR TITLE
Perbaikan untuk Kesalahan 'GetInhabitantCount'

### DIFF
--- a/left4bots_afterload.nut
+++ b/left4bots_afterload.nut
@@ -522,12 +522,12 @@ printl("enforce shotgun or sniper rifle");
 	}
 
 	// Periksa gerombolan musuh
-	local areas = {};
-	NavMesh.GetNavAreasInRadius(checkPos, 200, areas);
 	local commonInfected = 0;
-	foreach (area in areas)
+	local ent = null;
+	while(ent = Entities.FindByClassnameWithin(ent, "infected", checkPos, 200))
 	{
-		commonInfected += area.GetInhabitantCount(TEAM_INFECTED);
+		if (ent)
+			commonInfected++;
 	}
 
 	if (commonInfected > 10) // Jika ada lebih dari 10 musuh


### PR DESCRIPTION
Perubahan ini mengembalikan metode penghitungan musuh ke `Entities.FindByClassnameWithin` dengan pemeriksaan null tambahan. Ini memperbaiki kesalahan `GetInhabitantCount` yang tidak ada.