### PR TITLE
Perbaikan untuk Pemeriksaan Null NavArea

### DIFF
--- a/left4bots_afterload.nut
+++ b/left4bots_afterload.nut
@@ -504,10 +504,10 @@ printl("enforce shotgun or sniper rifle");
 		{
 			printl("Bot " + bot.GetPlayerName() + " mendeteksi pintu tertutup.");
 			local startNav = NavMesh.GetNearestNavArea(botOrigin);
-			if (bot.GetScriptScope().MovePos)
+			if (startNav && bot.GetScriptScope().MovePos)
 			{
 				local endNav = NavMesh.GetNearestNavArea(bot.GetScriptScope().MovePos);
-				if (startNav && endNav)
+				if (endNav)
 				{
 					local path = FindPath(startNav, endNav);
 					if (path)
@@ -534,10 +534,10 @@ printl("enforce shotgun or sniper rifle");
 	{
 		printl("Bot " + bot.GetPlayerName() + " mendeteksi gerombolan musuh.");
 		local startNav = NavMesh.GetNearestNavArea(botOrigin);
-		if (bot.GetScriptScope().MovePos)
+		if (startNav && bot.GetScriptScope().MovePos)
 		{
 			local endNav = NavMesh.GetNearestNavArea(bot.GetScriptScope().MovePos);
-			if (startNav && endNav)
+			if (endNav)
 			{
 				local path = FindPath(startNav, endNav);
 				if (path)


### PR DESCRIPTION
Perubahan ini menambahkan pemeriksaan untuk memastikan bahwa `startNav` dan `endNav` tidak null sebelum memanggil `FindPath`. Ini memperbaiki kesalahan `wrong number of parameters` yang terjadi ketika area navigasi tidak ditemukan.